### PR TITLE
Teach esx to not crash when scrolling through document IDs only

### DIFF
--- a/cmd/esx/scroll.go
+++ b/cmd/esx/scroll.go
@@ -51,9 +51,13 @@ func doScroll(client *elastic.Client) error {
 		}
 		for _, hit := range results.Hits.Hits {
 			var source map[string]interface{}
-			err := json.Unmarshal(*hit.Source, &source)
-			if err != nil {
-				return err
+			if hit.Source != nil {
+			    err := json.Unmarshal(*hit.Source, &source)
+			    if err != nil {
+			        return err
+			    }
+			} else {
+			    source = make(map[string]interface{})
 			}
 			source["_index"] = hit.Index
 			source["_type"] = hit.Type


### PR DESCRIPTION
# Description

There are use cases for scrolling through documents via ```esx``` where we only want document IDs returned. This can be done by using a JSON query with ```"stored_fields": []```, causing the document body to be omitted.

Unfortunately this currently crashes ```esx``` because it still tries to unmarshal the document body.

This PR fixes the issue.